### PR TITLE
Fix: GitHub Workflow trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: publish crates
 
 on:
+  push:
+  pull_request:
   release:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,5 +1,7 @@
 name: Spellcheck
-on: [push]
+on:
+  - push
+  - pull_request
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: tests
-on: [push]
+on:
+  - push
+  - pull_request
 jobs:
   tests:
     name: tests


### PR DESCRIPTION
GitHub Workflow was triggered only when push event was fired.
Now it is also triggered when pull_request event is fired.
This enables external contributors to run tests when they send pull requests.
(push event is fired when push is done to forked repository, but push event is not fired when push is done to kitsuyui's repository)
