### PR TITLE
Avoid duplicate pull_request and push in GitHub Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: publish crates
 
 on:
-  push:
   pull_request:
+    types: [opened, synchronize]
   release:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,5 @@
 name: Spellcheck
 on:
-  - push
   - pull_request
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,5 @@
 name: tests
 on:
-  - push
   - pull_request
 jobs:
   tests:

--- a/src/node_utils.rs
+++ b/src/node_utils.rs
@@ -61,8 +61,8 @@ fn node_to_table<'a>(node: impl Into<Node<'a>>) -> Result<Table<Node<'a>>, Error
         for td_node in t.td_nodes(*tr_node)? {
             let mut col_index = 0;
             let Some(element) = td_node.element() else {
-                    return Err(Error::InvalidDocument);
-                };
+                return Err(Error::InvalidDocument);
+            };
             let (row_size, col_size) = element_utils::extract_rowspan_and_colspan(element);
             while map.contains_key(&(row_index, col_index)) {
                 col_index += 1;


### PR DESCRIPTION
push is not necessary if there is a pull_request synchronize
