### PR TITLE
Revert "Update codecov/codecov-action action to v4"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
           cargo llvm-cov --lcov --output-path coverage.lcov
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.lcov


### PR DESCRIPTION
Reverts kitsuyui/sxd_html_table#17

v4 is currently in beta.

https://github.com/codecov/codecov-action/issues/1089

```
Unable to resolve action `codecov/codecov-action@v4`, unable to find version `v4`
```