### PR TITLE
Add rustfmt and clippy to the toolchain in CI explicitly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
           fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
       # For incremental builds
       - name: git-restore-mtime


### PR DESCRIPTION
It seems that the older version of rust-toolchain action installs rustfmt and clippy by default,
but the newer version does not.

So we need to specify them explicitly.
