### PR TITLE
Update coverage badge to Octocov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![crates.io](https://img.shields.io/crates/d/sxd_html_table)](https://crates.io/crates/sxd_html_table)
 [![tests](https://github.com/kitsuyui/sxd_html_table/actions/workflows/test.yml/badge.svg)](https://github.com/kitsuyui/sxd_html_table/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/kitsuyui/sxd_html_table/branch/main/graph/badge.svg?token=CG4FPNVJI3)](https://codecov.io/gh/kitsuyui/sxd_html_table)
+![Coverage](https://raw.githubusercontent.com/kitsuyui/octocov-central/main/badges/kitsuyui/sxd_html_table/coverage.svg)
 [![license](https://img.shields.io/crates/l/sxd_html_table)](https://github.com/kitsuyui/sxd_html_table#license)
 
 # Provide features related to HTML tables


### PR DESCRIPTION
## Summary
- Replace Codecov badge with Octocov coverage badge.
