### PR TITLE
Handle rowspan zero through the row group

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,17 +255,25 @@ mod tests {
                     <tr><td>e</td><td rowspan="a" colspan="b">f</td><td>g</td></tr>
                     <tr><td>h</td><td>i</td></tr>
                 </table>
+
+                <!-- rowspan="0" spans to the end of the row group -->
+                <table>
+                    <tr><td rowspan="0">a</td><td>b</td></tr>
+                    <tr><td>c</td></tr>
+                    <tr><td>d</td></tr>
+                </table>
             </body>
         </html>
         "#;
 
         let result = extract_table_texts_from_document(html).unwrap();
-        assert_eq!(result.len(), 6);
+        assert_eq!(result.len(), 7);
         assert_eq!(result[0].to_csv().unwrap(), "A,A,B\nA,A,C\n");
         assert_eq!(result[1].to_csv().unwrap(), "a,b,c\nd,e,f\n");
         assert_eq!(result[2].to_csv().unwrap(), "a,b,c,d\ne,f,f,d\ni,j,k,l\n");
         assert_eq!(result[3].to_csv().unwrap(), "a,b,c,d\ne,f,f,f\ni,j,k,l\n");
         assert_eq!(result[4].to_csv().unwrap(), "a,b,c,d\ne,f,f,g\nh,f,f,i\n");
         assert_eq!(result[5].to_csv().unwrap(), "a,b,c,d\ne,f,g,\nh,i,,\n");
+        assert_eq!(result[6].to_csv().unwrap(), "a,b\na,c\na,d\n");
     }
 }

--- a/src/node_utils.rs
+++ b/src/node_utils.rs
@@ -57,13 +57,17 @@ pub fn extract_table_nodes_to_table<'a>(
 fn node_to_table<'a>(node: impl Into<Node<'a>>) -> Result<Table<Node<'a>>, Error> {
     let mut map: HashMap<(usize, usize), Node> = HashMap::new();
     let t = TableSupport(node.into());
-    for (row_index, tr_node) in t.tr_nodes()?.iter().enumerate() {
+    let tr_nodes = t.tr_nodes()?;
+    for (row_index, tr_node) in tr_nodes.iter().enumerate() {
         for td_node in t.td_nodes(*tr_node)? {
             let mut col_index = 0;
             let Some(element) = td_node.element() else {
                 return Err(Error::InvalidDocument);
             };
-            let (row_size, col_size) = element_utils::extract_rowspan_and_colspan(element);
+            let (mut row_size, col_size) = element_utils::extract_rowspan_and_colspan(element);
+            if row_size == 0 {
+                row_size = tr_nodes.len() - row_index;
+            }
             while map.contains_key(&(row_index, col_index)) {
                 col_index += 1;
             }


### PR DESCRIPTION
## Summary

Handle `rowspan="0"` as spanning through the remaining rows in the table row group.

## Details

- Reuse the parsed table row list while building the table grid.
- Convert `rowspan="0"` to the number of rows from the current row through the end of the row group.
- Add a CSV regression case covering a cell that spans all remaining rows.

## Verification

- `cargo fmt --check`
- `cargo test`
- `cargo clippy -- -D warnings`
- `cargo check`
- `git diff --check`
