### PR TITLE
Pin publish and coverage workflow actions

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -17,20 +17,20 @@ jobs:
       # For incremental builds
       CARGO_INCREMENTAL: 1
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         # For incremental builds
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
 
       # For incremental builds
       - name: git-restore-mtime
-        uses: chetan/git-restore-mtime-action@v2.3
+        uses: chetan/git-restore-mtime-action@d186aca54f8760da4dec55313195e51ed3ebb0b3 # v2.3
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/bin/
@@ -47,7 +47,7 @@ jobs:
 
       # See also: https://github.com/k1LoW/octocov-action
       - name: Report coverage with octocov
-        uses: k1LoW/octocov-action@v1
+        uses: k1LoW/octocov-action@b3b6ee60482a667950f87553abf1df63217235d9 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config: .octocov.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,16 +7,19 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
## Summary

- Pin publish workflow actions to immutable commit SHAs.
- Pin coverage workflow actions to immutable commit SHAs.
- Add explicit `contents: read` permissions to the publish workflow.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; %w[.github/workflows/publish.yml .github/workflows/octocov.yml].each { |f| YAML.load_file(f) }; puts "yaml ok"'`\n- `actionlint .github/workflows/publish.yml .github/workflows/octocov.yml`\n- `cargo fmt --all -- --check`\n- `cargo check`\n- `cargo clippy --all-targets --all-features -- -D warnings`\n- `cargo build --release --all-features`\n- `cargo test --all-features`\n\nNo crates.io publish or publish dry-run command was run.