### PR TITLE
Declare read-only test workflow permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   tests:
     name: tests
@@ -48,4 +50,3 @@ jobs:
         run: |
           cargo install cargo-llvm-cov || true  # when already cached
           cargo llvm-cov --lcov --output-path coverage.lcov
-


### PR DESCRIPTION
## Summary

- Add an explicit read-only `GITHUB_TOKEN` permission block to the tests workflow.
- Keep the workflow limited to repository contents access, which is enough for checkout and Rust validation steps.

## Validation

- `actionlint .github/workflows/*.yml`
- `git diff --check origin/main...HEAD`