### PR TITLE
Pin test and spellcheck workflow actions to commit SHA

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@9108d679c02a52824376afcf071715fdaaa2a4e4 # main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,20 +17,20 @@ jobs:
       # For incremental builds
       CARGO_INCREMENTAL: 1
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         # For incremental builds
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt, clippy
 
       # For incremental builds
       - name: git-restore-mtime
-        uses: chetan/git-restore-mtime-action@v2.3
+        uses: chetan/git-restore-mtime-action@d186aca54f8760da4dec55313195e51ed3ebb0b3 # v2.3
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
## Summary
- Replace tag/branch refs in `.github/workflows/test.yml` and `.github/workflows/spellcheck.yml` with 40-char commit SHAs plus `# <tag>` comments.
- The SHAs match the values already used in `.github/workflows/octocov.yml` and `.github/workflows/publish.yml`, so the repository converges on a single set of pinned digests.
- Renovate (`helpers:pinGitHubActionDigests`) keeps the digests up to date going forward.

| file | before | after |
| --- | --- | --- |
| `test.yml:20` | `actions/checkout@v6` | `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6` |
| `test.yml:25` | `dtolnay/rust-toolchain@stable` | `dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable` |
| `test.yml:31` | `chetan/git-restore-mtime-action@v2.3` | `chetan/git-restore-mtime-action@d186aca54f8760da4dec55313195e51ed3ebb0b3 # v2.3` |
| `test.yml:33` | `actions/cache@v5` | `actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5` |
| `spellcheck.yml:8` | `kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main` | `...@9108d679c02a52824376afcf071715fdaaa2a4e4 # main` |

## Test plan
- [ ] tests workflow passes on this PR
- [ ] Spellcheck workflow passes on this PR