### PR TITLE
Add workflow concurrency controls

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,10 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,11 @@ on:
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Summary
- add top-level concurrency controls to the test and coverage workflows
- add concurrency to the crate publishing workflow while preserving release publish runs

## Verification
- actionlint .github/workflows/octocov.yml .github/workflows/publish.yml .github/workflows/test.yml
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo check
- cargo build
- cargo test
- git diff --check
- implement-validator: overall: pass
