### PR TITLE
Fix empty table returning 1x1 instead of 0x0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,21 @@ mod tests {
     }
 
     #[test]
+    fn test_empty_table() {
+        let html = r#"<html><body><table></table></body></html>"#;
+        let result = extract_table_texts_from_document(html).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].rows().len(), 0);
+        assert_eq!(result[0].to_csv().unwrap(), "");
+
+        let html = r#"<html><body><table><tbody></tbody></table></body></html>"#;
+        let result = extract_table_texts_from_document(html).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].rows().len(), 0);
+        assert_eq!(result[0].to_csv().unwrap(), "");
+    }
+
+    #[test]
     fn test_find_table_from_document() {
         // found 1 table
         let html = r#"

--- a/src/node_utils.rs
+++ b/src/node_utils.rs
@@ -80,8 +80,18 @@ fn node_to_table<'a>(node: impl Into<Node<'a>>) -> Result<Table<Node<'a>>, Error
             }
         }
     }
-    let rows = map.keys().map(|(i, _)| i).max().unwrap_or(&0) + 1;
-    let cols = map.keys().map(|(_, j)| j).max().unwrap_or(&0) + 1;
+    let rows = map
+        .keys()
+        .map(|(i, _)| i)
+        .max()
+        .map(|&i| i + 1)
+        .unwrap_or(0);
+    let cols = map
+        .keys()
+        .map(|(_, j)| j)
+        .max()
+        .map(|&j| j + 1)
+        .unwrap_or(0);
     let mut table = Table::new((rows, cols));
     for ((i, j), item) in map {
         table.set(i, j, item);


### PR DESCRIPTION
## Summary

`node_to_table` returned a 1×1 `Table` for HTML tables with no cell elements (`<td>`/`<th>`), instead of the correct 0×0 empty table.

The root cause was the size calculation:

```rust
// Before — returns 1 when map is empty
let rows = map.keys().map(|(i, _)| i).max().unwrap_or(&0) + 1;
let cols = map.keys().map(|(_, j)| j).max().unwrap_or(&0) + 1;
```

When `map` is empty, `max()` returns `None`, `unwrap_or(&0)` yields `&0`, and adding 1 gives size 1. The fix uses `map(|&i| i + 1).unwrap_or(0)` so that an empty map produces size 0:

```rust
// After — returns 0 when map is empty
let rows = map.keys().map(|(i, _)| i).max().map(|&i| i + 1).unwrap_or(0);
let cols = map.keys().map(|(_, j)| j).max().map(|&j| j + 1).unwrap_or(0);
```

## Changes

- `src/node_utils.rs`: Fix size calculation for empty cell map
- `src/lib.rs`: Add regression tests for `<table></table>` and `<table><tbody></tbody></table>`

## Validation

- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo test` ✓ (5 tests pass including new `test_empty_table`)
