### PR TITLE
Fix XPath to include thead and tfoot rows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,4 +303,98 @@ mod tests {
             "failed to convert table to CSV"
         );
     }
+
+    #[test]
+    fn test_thead_rows_included() {
+        let html = r#"
+        <html>
+            <body>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Age</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Alice</td>
+                            <td>30</td>
+                        </tr>
+                        <tr>
+                            <td>Bob</td>
+                            <td>25</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </body>
+        </html>
+        "#;
+        let result = extract_table_texts_from_document(html).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].to_csv().unwrap(), "Name,Age\nAlice,30\nBob,25\n");
+    }
+
+    #[test]
+    fn test_tfoot_rows_included() {
+        let html = r#"
+        <html>
+            <body>
+                <table>
+                    <tbody>
+                        <tr>
+                            <td>Alice</td>
+                            <td>30</td>
+                        </tr>
+                    </tbody>
+                    <tfoot>
+                        <tr>
+                            <td>Total</td>
+                            <td>1</td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </body>
+        </html>
+        "#;
+        let result = extract_table_texts_from_document(html).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].to_csv().unwrap(), "Alice,30\nTotal,1\n");
+    }
+
+    #[test]
+    fn test_to_string_table_with_header_thead() {
+        let html = r#"
+        <html>
+            <body>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Score</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Alice</td>
+                            <td>100</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </body>
+        </html>
+        "#;
+        let package = sxd_html::parse_html(html);
+        let document = package.as_document();
+        let tables = extract_table_nodes_to_table(document.root()).unwrap();
+        assert_eq!(tables.len(), 1);
+        let with_header = tables[0].to_string_table_with_header();
+        let rows = with_header.rows();
+        // THEAD row: both cells should be flagged as headers (th elements)
+        assert_eq!(rows[0][0], Some(&("Name".to_string(), true)));
+        assert_eq!(rows[0][1], Some(&("Score".to_string(), true)));
+        // TBODY row: cells should not be flagged as headers (td elements)
+        assert_eq!(rows[1][0], Some(&("Alice".to_string(), false)));
+        assert_eq!(rows[1][1], Some(&("100".to_string(), false)));
+    }
 }

--- a/src/node_utils.rs
+++ b/src/node_utils.rs
@@ -8,7 +8,7 @@ struct TableSupport<'a>(Node<'a>);
 
 impl<'a> TableSupport<'a> {
     fn tr_nodes(&self) -> Result<Vec<Node<'a>>, Error> {
-        let tr_nodes = match evaluate_xpath_node(self.0, "./tbody/tr") {
+        let tr_nodes = match evaluate_xpath_node(self.0, "./thead/tr|./tbody/tr|./tfoot/tr") {
             Ok(Value::Nodeset(tr_nodes)) => tr_nodes,
             _ => {
                 return Err(Error::InvalidDocument(


### PR DESCRIPTION
## Summary

The XPath expression `./tbody/tr` used in `node_utils.rs` only matched rows
inside `<tbody>`, silently dropping any rows in `<thead>` or `<tfoot>` sections.

HTML tables commonly place header rows inside `<thead>`:
```html
<table>
  <thead><tr><th>Name</th><th>Age</th></tr></thead>
  <tbody><tr><td>Alice</td><td>30</td></tr></tbody>
</table>
```

With the old XPath, `extract_table_nodes_to_table` returned only the body rows,
making `to_string_table_with_header()` unable to detect header rows from THEAD.

## Change

- `src/node_utils.rs`: Change XPath from `./tbody/tr` to
  `./thead/tr|./tbody/tr|./tfoot/tr`. Rows are collected in document order
  (THEAD → TBODY → TFOOT) via the existing `.document_order()` call.

## Tests

Three new tests added in `src/lib.rs`:
- `test_thead_rows_included` — THEAD rows appear in table output
- `test_tfoot_rows_included` — TFOOT rows appear in table output
- `test_to_string_table_with_header_thead` — `to_string_table_with_header()` flags
  THEAD `<th>` cells as headers when THEAD rows are present

All existing tests continue to pass.

## Trade-offs

- `rowspan="0"` semantics span to the end of the entire row set rather than
  the individual row group (THEAD/TBODY/TFOOT). This is an existing limitation
  independent of this fix and affects an uncommon edge case.
