### PR TITLE
Clamp rowspan to remaining rows per HTML5 §4.9.11

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,4 +499,25 @@ mod tests {
         assert_eq!(rows[1][0], Some(&("Alice".to_string(), false)));
         assert_eq!(rows[1][1], Some(&("100".to_string(), false)));
     }
+
+    #[test]
+    fn test_rowspan_exceeds_actual_rows() {
+        // rowspan larger than the actual row count must be clamped to the remaining rows
+        // per HTML5 §4.9.11, not produce phantom rows
+        let html = r#"
+        <html>
+            <body>
+                <table>
+                    <tr><td rowspan="99999">a</td><td>b</td></tr>
+                    <tr><td>c</td></tr>
+                    <tr><td>d</td></tr>
+                </table>
+            </body>
+        </html>
+        "#;
+        let result = extract_table_texts_from_document(html).unwrap();
+        assert_eq!(result.len(), 1);
+        // table has exactly 3 rows, not 99999
+        assert_eq!(result[0].to_csv().unwrap(), "a,b\na,c\na,d\n");
+    }
 }

--- a/src/node_utils.rs
+++ b/src/node_utils.rs
@@ -81,8 +81,9 @@ fn node_to_table<'a>(node: impl Into<Node<'a>>) -> Result<Table<Node<'a>>, Error
                 ));
             };
             let (mut row_size, col_size) = element_utils::extract_rowspan_and_colspan(element);
-            if row_size == 0 {
-                row_size = tr_nodes.len() - row_index;
+            let remaining_rows = tr_nodes.len() - row_index;
+            if row_size == 0 || row_size > remaining_rows {
+                row_size = remaining_rows;
             }
             while col_index < MAX_TABLE_COLUMNS && map.contains_key(&(row_index, col_index)) {
                 col_index += 1;


### PR DESCRIPTION
## Summary

HTML5 §4.9.11 states that when a `rowspan` value exceeds the number of remaining rows in a table, the cell must span only to the end of the row group. Previously, only `rowspan="0"` was clamped to the remaining row count; positive values larger than the actual row count were passed through unchanged, causing the returned `Table` to contain phantom rows that do not exist in the HTML source.

**Change:**
- In `node_utils.rs`, compute `remaining_rows = tr_nodes.len() - row_index` before the rowspan check, and clamp `row_size` to `remaining_rows` when `row_size` is zero (existing behaviour) or exceeds `remaining_rows` (new fix).
- Add a regression test: a 3-row table with `rowspan="99999"` on the first cell must produce exactly 3 rows.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (5/5 pass, including new `test_rowspan_exceeds_actual_rows`)
