### PR TITLE
Cap rowspan and colspan at HTML5 §4.9.11 limits to prevent OOM

### DIFF
--- a/src/element_utils.rs
+++ b/src/element_utils.rs
@@ -1,13 +1,19 @@
+/// Maximum rowspan per HTML5 §4.9.11 (non-zero positive limit).
+const MAX_ROWSPAN: usize = 65534;
+/// Maximum colspan per HTML5 §4.9.11.
+const MAX_COLSPAN: usize = 1000;
+
 pub fn extract_rowspan_and_colspan(element: sxd_document::dom::Element) -> (usize, usize) {
-    let rowspan = extract_span(element, "rowspan");
-    let colspan = extract_span(element, "colspan");
+    let rowspan = extract_span(element, "rowspan", MAX_ROWSPAN);
+    let colspan = extract_span(element, "colspan", MAX_COLSPAN);
     (rowspan, colspan)
 }
 
-fn extract_span(element: sxd_document::dom::Element, name: &str) -> usize {
-    element
+fn extract_span(element: sxd_document::dom::Element, name: &str, max: usize) -> usize {
+    let raw = element
         .attribute_value(name)
         .unwrap_or("1")
         .parse::<usize>()
-        .unwrap_or(1)
+        .unwrap_or(1);
+    raw.min(max)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,4 +303,25 @@ mod tests {
             "failed to convert table to CSV"
         );
     }
+
+    #[test]
+    fn test_oversized_spans_are_capped() {
+        // colspan="99999" must be capped at HTML5 max (1000) to prevent OOM
+        let html = r#"
+        <html>
+            <body>
+                <table>
+                    <tr><td colspan="99999">a</td></tr>
+                    <tr><td>b</td><td>c</td></tr>
+                </table>
+            </body>
+        </html>
+        "#;
+        let result = extract_table_texts_from_document(html).unwrap();
+        assert_eq!(result.len(), 1);
+        let rows = result[0].rows();
+        // The table must have exactly 2 rows and at most 1000 columns, not 99999
+        assert_eq!(rows.len(), 2);
+        assert!(rows[0].len() <= 1000);
+    }
 }


### PR DESCRIPTION
## Summary

HTML attributes are untrusted external input. Without an upper bound on `rowspan` and `colspan`, parsing `<td rowspan="999999" colspan="999999">` causes the double loop in `node_to_table` to execute O(rowspan × colspan) ≈ 10¹² iterations, inserting that many entries into the `HashMap`. `Table::new` then allocates a `Vec` of the same size, leading to OOM or process hang.

**Change:**
- Add `MAX_ROWSPAN = 65534` and `MAX_COLSPAN = 1000` in `element_utils.rs` per HTML5 §4.9.11.
- Clamp the parsed `usize` value in `extract_span` using `.min(max)` before returning.
- Add a regression test that verifies `colspan="99999"` produces a table with at most 1000 columns.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (5/5 pass, including new `test_oversized_spans_are_capped`)
