### PR TITLE
Add context to InvalidDocument and implement Display for Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,20 @@ pub use crate::table::Table;
 #[derive(Debug)]
 pub enum Error {
     TableNotFound,
-    InvalidDocument,
+    InvalidDocument(&'static str),
     FailedToConvertToCSV,
     XPathEvaluationError(sxd_xpath::Error),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TableNotFound => f.write_str("no table found in document"),
+            Self::InvalidDocument(ctx) => write!(f, "invalid document: {ctx}"),
+            Self::FailedToConvertToCSV => f.write_str("failed to convert table to CSV"),
+            Self::XPathEvaluationError(e) => write!(f, "XPath evaluation error: {e}"),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -275,5 +286,21 @@ mod tests {
         assert_eq!(result[4].to_csv().unwrap(), "a,b,c,d\ne,f,f,g\nh,f,f,i\n");
         assert_eq!(result[5].to_csv().unwrap(), "a,b,c,d\ne,f,g,\nh,i,,\n");
         assert_eq!(result[6].to_csv().unwrap(), "a,b\na,c\na,d\n");
+    }
+
+    #[test]
+    fn test_error_display() {
+        assert_eq!(
+            Error::TableNotFound.to_string(),
+            "no table found in document"
+        );
+        assert_eq!(
+            Error::InvalidDocument("XPath ./tbody/tr did not return a nodeset").to_string(),
+            "invalid document: XPath ./tbody/tr did not return a nodeset"
+        );
+        assert_eq!(
+            Error::FailedToConvertToCSV.to_string(),
+            "failed to convert table to CSV"
+        );
     }
 }

--- a/src/node_utils.rs
+++ b/src/node_utils.rs
@@ -10,14 +10,22 @@ impl<'a> TableSupport<'a> {
     fn tr_nodes(&self) -> Result<Vec<Node<'a>>, Error> {
         let tr_nodes = match evaluate_xpath_node(self.0, "./tbody/tr") {
             Ok(Value::Nodeset(tr_nodes)) => tr_nodes,
-            _ => return Err(Error::InvalidDocument),
+            _ => {
+                return Err(Error::InvalidDocument(
+                    "XPath ./tbody/tr did not return a nodeset",
+                ))
+            }
         };
         Ok(tr_nodes.document_order())
     }
     fn td_nodes(&self, tr: Node<'a>) -> Result<Vec<Node<'a>>, Error> {
         let td_nodes = match evaluate_xpath_node(tr, "./td|./th") {
             Ok(Value::Nodeset(td_nodes)) => td_nodes,
-            _ => return Err(Error::InvalidDocument),
+            _ => {
+                return Err(Error::InvalidDocument(
+                    "XPath ./td|./th did not return a nodeset",
+                ))
+            }
         };
         Ok(td_nodes.document_order())
     }
@@ -62,7 +70,9 @@ fn node_to_table<'a>(node: impl Into<Node<'a>>) -> Result<Table<Node<'a>>, Error
         for td_node in t.td_nodes(*tr_node)? {
             let mut col_index = 0;
             let Some(element) = td_node.element() else {
-                return Err(Error::InvalidDocument);
+                return Err(Error::InvalidDocument(
+                    "td/th node could not be cast to an element",
+                ));
             };
             let (mut row_size, col_size) = element_utils::extract_rowspan_and_colspan(element);
             if row_size == 0 {


### PR DESCRIPTION
## Summary

`Error::InvalidDocument` was returned from three distinct failure sites in `node_to_table` but carried no information about which step failed, making it impossible for callers to diagnose the root cause without reading source code. `std::fmt::Display` was also unimplemented, so errors could only be formatted with `{:?}`.

**Changes:**
- `Error::InvalidDocument` now holds a `&'static str` context string; the three return sites in `node_utils.rs` each supply a distinct message (`"XPath ./tbody/tr did not return a nodeset"`, `"XPath ./td|./th did not return a nodeset"`, `"td/th node could not be cast to an element"`).
- `impl std::fmt::Display for Error` is added for all variants, enabling callers to use `err.to_string()` or the `{}` format specifier.
- A regression test `test_error_display` verifies the Display output for `TableNotFound`, `InvalidDocument`, and `FailedToConvertToCSV`.

**Note:** This PR changes the public API (`InvalidDocument` variant payload) and conflicts in scope with [#56](https://github.com/kitsuyui/sxd_html_table/pull/56), which also adds `Display`. They should be sequenced: #56 can be merged first and this PR rebased to build on it, or they can be combined.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` (5/5 pass, including new `test_error_display`)
