### PR TITLE
Document Table::set bounds panics

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -8,7 +8,23 @@ pub struct Table<T> {
 }
 
 impl<T> Table<T> {
+    /// Sets the item at the specified row and column.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `row` is greater than or equal to the table row count, or
+    /// if `col` is greater than or equal to the table column count.
     pub fn set(&mut self, row: usize, col: usize, item: T) {
+        assert!(
+            row < self.size.0,
+            "row index {row} out of bounds for table with {} rows",
+            self.size.0
+        );
+        assert!(
+            col < self.size.1,
+            "column index {col} out of bounds for table with {} columns",
+            self.size.1
+        );
         self.cells[row * self.size.1 + col] = Some(item);
     }
 
@@ -104,5 +120,35 @@ where
         self.write_csv(&mut buf)?;
         let bytes = buf.into_inner().map_err(|_| Error::FailedToConvertToCSV)?;
         String::from_utf8(bytes).map_err(|_| Error::FailedToConvertToCSV)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_updates_cell_when_index_is_in_bounds() {
+        let mut table = Table::new((2, 2));
+
+        table.set(1, 1, 42);
+
+        assert_eq!(table.rows()[1][1], Some(&42));
+    }
+
+    #[test]
+    #[should_panic(expected = "row index 2 out of bounds for table with 2 rows")]
+    fn set_panics_when_row_is_out_of_bounds() {
+        let mut table = Table::new((2, 2));
+
+        table.set(2, 0, 42);
+    }
+
+    #[test]
+    #[should_panic(expected = "column index 2 out of bounds for table with 2 columns")]
+    fn set_panics_when_column_is_out_of_bounds() {
+        let mut table = Table::new((2, 2));
+
+        table.set(0, 2, 42);
     }
 }


### PR DESCRIPTION
## Summary
- document the bounds contract for `Table::set`
- check row and column bounds before indexing so panic messages are explicit
- add tests for in-bounds updates and both out-of-bounds panic cases

## Checks
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check`
- `cargo test`
- `cargo build --release --all-features`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
