### PR TITLE
Mark Error enum as non_exhaustive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub use crate::node_utils::extract_table_nodes_to_table;
 pub use crate::table::Table;
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     TableNotFound,
     InvalidDocument,


### PR DESCRIPTION
## Summary

The public `Error` enum in `src/lib.rs` lacked the `#[non_exhaustive]` attribute. Adding a new variant (e.g. `RowspanOverflow`) would break every downstream crate that exhaustively matches on `Error`, forcing a semver-major bump even for what should be a minor addition.

`#[non_exhaustive]` declares that the enum may grow and requires downstream code to add a wildcard `_` arm. This turns future variant additions into backward-compatible minor-version changes.

## Changes

- `src/lib.rs`: add `#[non_exhaustive]` to `pub enum Error`

## Test plan

- `cargo test` — 4 tests pass (no change needed; tests in the same crate are not affected by `#[non_exhaustive]`)
- `cargo clippy` — no warnings