### PR TITLE
Return TableNotFound when no tables exist in the document

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,13 +81,13 @@ mod tests {
             </body>
         </html>
         "#;
-        let result = extract_table_texts_from_document(html).unwrap();
-        assert_eq!(result.len(), 0);
+        let result = extract_table_texts_from_document(html);
+        assert!(matches!(result, Err(Error::TableNotFound)));
 
         // empty html
         let html = r#""#;
-        let result = extract_table_texts_from_document(html).unwrap();
-        assert_eq!(result.len(), 0);
+        let result = extract_table_texts_from_document(html);
+        assert!(matches!(result, Err(Error::TableNotFound)));
     }
 
     #[test]

--- a/src/node_utils.rs
+++ b/src/node_utils.rs
@@ -39,9 +39,13 @@ pub fn evaluate_xpath_node<'a>(
 fn extract_table_nodes<'a>(node: impl Into<Node<'a>>) -> Result<Vec<Node<'a>>, Error> {
     let val = evaluate_xpath_node(node, "//table").map_err(Error::XPathEvaluationError)?;
     let Value::Nodeset(table_nodes) = val else {
-        return Err(Error::TableNotFound);
+        unreachable!("//table XPath always returns a Nodeset");
     };
-    Ok(table_nodes.document_order())
+    let nodes = table_nodes.document_order();
+    if nodes.is_empty() {
+        return Err(Error::TableNotFound);
+    }
+    Ok(nodes)
 }
 
 pub fn extract_table_nodes_to_table<'a>(


### PR DESCRIPTION
## Problem

`Error::TableNotFound` was an unreachable variant. The `//table` XPath expression
always returns `Value::Nodeset` (including an empty one for documents with no
tables), so the `else` branch in `extract_table_nodes` could never execute.

This meant:
- Users who matched on `Error::TableNotFound` wrote dead code that never ran
- The actual "no tables found" case silently returned `Ok(vec![])`, while the
  error enum implied a distinct `TableNotFound` error path existed
- The public API was misleading about which error conditions were possible

## Fix

Give `Error::TableNotFound` its intended meaning: return it when the document
contains no `<table>` elements.

- Replace the unreachable `else` branch with `unreachable!()` to document the
  XPath invariant
- Add an empty-nodeset check: if `//table` returns no nodes, return
  `Err(Error::TableNotFound)`

## Breaking change

`extract_table_nodes_to_table` now returns `Err(Error::TableNotFound)` instead
of `Ok(vec![])` when the HTML document contains no `<table>` elements. Callers
that previously checked `result.is_empty()` should now handle
`Err(Error::TableNotFound)`.

## Testing

- Updated existing tests to assert `Err(Error::TableNotFound)` for the "no
  tables" and "empty HTML" cases
- All 4 unit tests pass (`cargo test`)
- No clippy warnings (`cargo clippy -- -D warnings`)
