### PR TITLE
Treat zero colspan as one

### DIFF
--- a/src/element_utils.rs
+++ b/src/element_utils.rs
@@ -1,6 +1,6 @@
 pub fn extract_rowspan_and_colspan(element: sxd_document::dom::Element) -> (usize, usize) {
     let rowspan = extract_span(element, "rowspan");
-    let colspan = extract_span(element, "colspan");
+    let colspan = extract_colspan(element);
     (rowspan, colspan)
 }
 
@@ -10,4 +10,8 @@ fn extract_span(element: sxd_document::dom::Element, name: &str) -> usize {
         .unwrap_or("1")
         .parse::<usize>()
         .unwrap_or(1)
+}
+
+fn extract_colspan(element: sxd_document::dom::Element) -> usize {
+    extract_span(element, "colspan").max(1)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,26 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].to_csv().unwrap(), "A,A,B\nC,D,E\n");
 
+        let html = r#"
+        <html>
+            <body>
+                <table>
+                    <tr>
+                        <td colspan="0">A</td>
+                        <td>B</td>
+                    </tr>
+                    <tr>
+                        <td>C</td>
+                        <td>D</td>
+                    </tr>
+                </table>
+            </body>
+        </html>
+        "#;
+        let result = extract_table_texts_from_document(html).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].to_csv().unwrap(), "A,B\nC,D\n");
+
         // more complex
         let html = r#"
         <html>


### PR DESCRIPTION
## Summary
- Treat `colspan="0"` as an invalid column span and preserve the cell as a single column.
- Keep the existing `rowspan="0"` row-group behavior unchanged.
- Add a regression test for zero colspan cells.

## Checks
- `cargo fmt --all -- --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check`
- `cargo build --release --all-features`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
