### PR TITLE
Exclude nested tables from extract_table_nodes_to_table results

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,6 +251,35 @@ mod tests {
     }
 
     #[test]
+    fn test_nested_table_excluded() {
+        // A nested <table> is not returned as a separate entry.
+        // Only the outermost table is returned; the inner table is accessible
+        // as a node within the outer table's cells.
+        let html = r#"
+        <html>
+            <body>
+                <table>
+                    <tr>
+                        <td>outer</td>
+                        <td>
+                            <table>
+                                <tr><td>inner</td></tr>
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            </body>
+        </html>
+        "#;
+        let result = extract_table_texts_from_document(html).unwrap();
+        assert_eq!(
+            result.len(),
+            1,
+            "nested table must not appear as a separate entry"
+        );
+    }
+
+    #[test]
     fn test_rowspan_and_colspan() {
         let html = r#"
         <html>

--- a/src/node_utils.rs
+++ b/src/node_utils.rs
@@ -63,7 +63,7 @@ pub fn evaluate_xpath_node<'a>(
 }
 
 fn extract_table_nodes<'a>(node: impl Into<Node<'a>>) -> Result<Vec<Node<'a>>, Error> {
-    let val = evaluate_xpath_node(node, "//table").map_err(Error::from)?;
+    let val = evaluate_xpath_node(node, "//table[not(ancestor::table)]").map_err(Error::from)?;
     let Value::Nodeset(table_nodes) = val else {
         unreachable!("//table XPath always returns a Nodeset");
     };


### PR DESCRIPTION
## Summary

Changed the XPath expression in `src/node_utils.rs` from `//table` to `//table[not(ancestor::table)]` so that `extract_table_nodes` (and by extension `extract_table_nodes_to_table`) returns only top-level tables and ignores tables that are nested inside another table.

## Problem

The previous expression `//table` matched every `<table>` element in the document, including tables nested inside `<td>` cells of an outer table. This caused two issues:

- **Duplicate rows**: cell content that happened to contain a nested table was processed twice — once as part of the outer table, and again as a separate table entry.
- **Contaminated cell values**: the nested table itself was returned as an independent table, with no surrounding context, which produced spurious entries in the result set.

## Changes

| File | Change |
|------|--------|
| `src/node_utils.rs` | XPath updated from `//table` → `//table[not(ancestor::table)]` |
| `src/lib.rs` | Added `test_nested_table_excluded` to assert that a nested `<table>` is not returned as a separate entry |

## Trade-off / Behavior Change

This is a **breaking change** for callers that relied on nested tables being returned as independent entries. After this fix, only the outermost table is returned; the inner table remains accessible as a subtree within the outer table's cells, but it will not appear as a separate element in the result vector.

If a caller needs to process nested tables independently, it must traverse the cell content of the returned top-level table manually.

## Test

`test_nested_table_excluded` in `src/lib.rs` constructs an HTML document with an outer table containing an inner table, calls `extract_table_texts_from_document`, and asserts that exactly one table (the outer one) is returned.
