### PR TITLE
Document parameter ordering for Table::new, Table::set, and extract_rowspan_and_colspan

### DIFF
--- a/src/element_utils.rs
+++ b/src/element_utils.rs
@@ -1,3 +1,7 @@
+/// Returns `(rowspan, colspan)` for an HTML element.
+///
+/// The first tuple element is the row span and the second is the column span.
+/// Missing or non-numeric attributes default to `1`.
 pub fn extract_rowspan_and_colspan(element: sxd_document::dom::Element) -> (usize, usize) {
     let rowspan = extract_span(element, "rowspan");
     let colspan = extract_span(element, "colspan");

--- a/src/table.rs
+++ b/src/table.rs
@@ -8,7 +8,10 @@ pub struct Table<T> {
 }
 
 impl<T> Table<T> {
-    /// Sets the item at the specified row and column.
+    /// Sets the cell at the given `(row, col)` position.
+    ///
+    /// Rows are zero-indexed from top; columns are zero-indexed from left.
+    /// The row index must come before the column index.
     ///
     /// # Panics
     ///
@@ -45,6 +48,10 @@ impl<T> Table<T>
 where
     T: Clone,
 {
+    /// Creates a new table with the given size.
+    ///
+    /// `size` is `(rows, cols)`: the first element is the row count and the
+    /// second is the column count.
     pub fn new(size: (usize, usize)) -> Self {
         Self {
             size,


### PR DESCRIPTION
## Summary

This PR adds doc comments to three functions to explicitly document tuple element ordering.

### Changes

- `Table::new`: documents that the `size` parameter is `(rows, cols)` — first element is row count, second is column count.
- `Table::set`: documents that arguments are `(row, col)` — row index before column index, both zero-indexed.
- `extract_rowspan_and_colspan`: documents that the return value is `(rowspan, colspan)` — first element is row span, second is column span.

### Motivation

All three functions use unnamed `(usize, usize)` tuples. Because both elements are the same type, the Rust compiler cannot detect transposition errors — calling `table.new((cols, rows))` or reading the return of `extract_rowspan_and_colspan` as `(colspan, rowspan)` compiles without warning. Explicit doc comments make the intended ordering visible in IDE tooltips and generated documentation, reducing the chance of silent logic bugs.

### Trade-offs

This PR adds no type-level enforcement. Introducing newtype wrappers (e.g., `Row(usize)` and `Col(usize)`) would provide compiler-checked safety but would be a breaking API change requiring a semver-major release. That is left as a potential follow-up. The doc comments in this PR are a non-breaking, low-friction improvement that can be shipped immediately.
