### PR TITLE
Move sxd_html to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,6 @@ repository = "https://github.com/kitsuyui/sxd_html_table"
 csv = "1.3.0"
 sxd-document = "0.3.2"
 sxd-xpath = "0.4.2"
+
+[dev-dependencies]
 sxd_html = "0.1.1"


### PR DESCRIPTION
## Summary
- Move `sxd_html` from normal dependencies to dev-dependencies.
- Keep tests using `sxd_html` without adding it to the dependency graph for library users.

## Checks
- `cargo fmt --all -- --check`
- `cargo metadata --no-deps --format-version 1`
- `cargo tree --edges normal --depth 1`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check`
- `cargo build --release --all-features`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
