### PR TITLE
Add a release tag version guard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,20 @@ jobs:
 
       - run: cargo build --release --all-features
 
+      - name: verify release tag matches crate version
+        if: github.event_name == 'release'
+        env:
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          tag_name="$RELEASE_TAG_NAME"
+          tag_version="${tag_name#v}"
+          crate_version="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json, sys; print(json.load(sys.stdin)["packages"][0]["version"])')"
+
+          if [ "$tag_version" != "$crate_version" ]; then
+            echo "::error::Release tag '$tag_name' does not match Cargo.toml version '$crate_version'."
+            exit 1
+          fi
+
       - name: publish (dry-run)
         if: github.event_name == 'release' && github.event.release.prerelease
         run: cargo publish --dry-run


### PR DESCRIPTION
## Summary
- Add a release-only check before publishing the crate.
- Compare the GitHub release tag, normalized without a leading `v`, with the package version from `Cargo.toml`.
- Stop `cargo publish` when the release tag and crate version differ.

## Checks
- `actionlint .github/workflows/publish.yml`
- local release guard comparison for matching and mismatched tags
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check`
- `cargo test`
- `cargo build --release --all-features`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
