### PR TITLE
Move Table<Node> impl from table.rs to node_utils.rs

### DIFF
--- a/src/node_utils.rs
+++ b/src/node_utils.rs
@@ -6,6 +6,22 @@ use crate::{element_utils, table::Table, Error};
 
 pub(crate) const MAX_TABLE_COLUMNS: usize = 1000;
 
+impl Table<Node<'_>> {
+    pub fn to_string_table(&self) -> Table<String> {
+        self.map(|_, _, node| node.string_value())
+    }
+
+    pub fn to_string_table_with_header(&self) -> Table<(String, bool)> {
+        self.map(|_, _, node| {
+            let Some(element) = node.element() else {
+                return (node.string_value(), false);
+            };
+            let is_header = element.name() == "th".into();
+            (node.string_value(), is_header)
+        })
+    }
+}
+
 struct TableSupport<'a>(Node<'a>);
 
 impl<'a> TableSupport<'a> {

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-use sxd_xpath::nodeset::Node;
-
 use crate::Error;
 
 fn sanitize_formula_injection(s: &str) -> Cow<'_, str> {
@@ -91,22 +89,6 @@ where
         }
     }
     new_table
-}
-
-impl Table<Node<'_>> {
-    pub fn to_string_table(&self) -> Table<String> {
-        self.map(|_, _, node| node.string_value())
-    }
-
-    pub fn to_string_table_with_header(&self) -> Table<(String, bool)> {
-        self.map(|_, _, node| {
-            let Some(element) = node.element() else {
-                return (node.string_value(), false);
-            };
-            let is_header = element.name() == "th".into();
-            (node.string_value(), is_header)
-        })
-    }
 }
 
 impl<T> Table<T>


### PR DESCRIPTION
## Summary

`table.rs` defines the generic `Table<T>` grid struct, but previously
it also held an `impl Table<Node<'_>>` block that imported
`sxd_xpath::nodeset::Node`. This created a dependency edge
`table` → `sxd_xpath` — a layer inversion where the generic data
structure depends on the XPath parser library.

Moving `to_string_table` and `to_string_table_with_header` into
`node_utils.rs` corrects this: `node_utils.rs` already owns the
`sxd_xpath` dependency, and `table.rs` becomes a pure generic
`T`-agnostic module.

## Changes

- `src/table.rs`: remove `use sxd_xpath::nodeset::Node` and the
  `impl Table<Node<'_>>` block.
- `src/node_utils.rs`: add the same `impl Table<Node<'_>>` block
  immediately after the existing imports.

## Verification

```
cargo fmt --all -- --check    # no changes
cargo clippy --all-targets --all-features -- -D warnings  # no warnings
cargo test                    # 4/4 tests pass
```

## Trade-offs

- No behavior change; all public methods remain accessible.
- A future `design` refactor could introduce a Cargo feature gate to
  make `sxd_xpath` an optional dependency for `Table<T>` users who
  do not need XPath node conversion.
