### PR TITLE
Bound table column placement during extraction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,4 +276,47 @@ mod tests {
         assert_eq!(result[5].to_csv().unwrap(), "a,b,c,d\ne,f,g,\nh,i,,\n");
         assert_eq!(result[6].to_csv().unwrap(), "a,b\na,c\na,d\n");
     }
+
+    #[test]
+    fn test_rejects_when_rowspan_fills_column_limit() {
+        let html = format!(
+            r#"
+        <html>
+            <body>
+                <table>
+                    <tr><td rowspan="0" colspan="{}">A</td></tr>
+                    <tr><td>B</td></tr>
+                </table>
+            </body>
+        </html>
+        "#,
+            crate::node_utils::MAX_TABLE_COLUMNS
+        );
+        match extract_table_texts_from_document(&html) {
+            Err(Error::InvalidDocument) => {}
+            Err(_) => panic!("expected InvalidDocument"),
+            Ok(_) => panic!("expected table extraction to fail"),
+        }
+    }
+
+    #[test]
+    fn test_rejects_colspan_larger_than_column_limit() {
+        let html = format!(
+            r#"
+        <html>
+            <body>
+                <table>
+                    <tr><td colspan="{}">A</td></tr>
+                </table>
+            </body>
+        </html>
+        "#,
+            crate::node_utils::MAX_TABLE_COLUMNS + 1
+        );
+        match extract_table_texts_from_document(&html) {
+            Err(Error::InvalidDocument) => {}
+            Err(_) => panic!("expected InvalidDocument"),
+            Ok(_) => panic!("expected table extraction to fail"),
+        }
+    }
 }

--- a/src/node_utils.rs
+++ b/src/node_utils.rs
@@ -4,6 +4,8 @@ use sxd_xpath::{nodeset::Node, Context, Factory, Value};
 
 use crate::{element_utils, table::Table, Error};
 
+pub(crate) const MAX_TABLE_COLUMNS: usize = 1000;
+
 struct TableSupport<'a>(Node<'a>);
 
 impl<'a> TableSupport<'a> {
@@ -68,8 +70,20 @@ fn node_to_table<'a>(node: impl Into<Node<'a>>) -> Result<Table<Node<'a>>, Error
             if row_size == 0 {
                 row_size = tr_nodes.len() - row_index;
             }
-            while map.contains_key(&(row_index, col_index)) {
+            while col_index < MAX_TABLE_COLUMNS && map.contains_key(&(row_index, col_index)) {
                 col_index += 1;
+            }
+            if col_index >= MAX_TABLE_COLUMNS {
+                return Err(Error::InvalidDocument);
+            }
+            if col_size > MAX_TABLE_COLUMNS {
+                return Err(Error::InvalidDocument);
+            }
+            let Some(end_col) = col_index.checked_add(col_size) else {
+                return Err(Error::InvalidDocument);
+            };
+            if end_col > MAX_TABLE_COLUMNS {
+                return Err(Error::InvalidDocument);
             }
             for k in 0..row_size {
                 for l in 0..col_size {


### PR DESCRIPTION
## Summary
Bound occupied-column scanning and placement during table extraction. Cells that would exceed the maximum column bound are now rejected, and regression tests cover the boundary behavior.

## Verification
- `cargo fmt --all -- --check`
- `cargo test`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo llvm-cov --lcov --output-path coverage.lcov`
- `git diff --check`
- implement-validator equivalent gate: overall pass