### PR TITLE
fix: guard against multiple rowspan=0 cells in the same row

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -575,4 +575,28 @@ mod tests {
         // table has exactly 3 rows, not 99999
         assert_eq!(result[0].to_csv().unwrap(), "a,b\na,c\na,d\n");
     }
+
+    #[test]
+    fn test_rowspan_zero_multiple_in_same_row() {
+        // When a row has multiple rowspan=0 cells, only the first one spans to the
+        // end of the row group. Subsequent rowspan=0 cells are treated as rowspan=1
+        // to prevent state-machine ambiguity (multiple cells competing for the same
+        // row-group span).
+        let html = r#"
+        <html>
+            <body>
+                <table>
+                    <tr><td rowspan="0">a</td><td rowspan="0">b</td></tr>
+                    <tr><td>c</td></tr>
+                </table>
+            </body>
+        </html>
+        "#;
+        let result = extract_table_texts_from_document(html).unwrap();
+        assert_eq!(result.len(), 1);
+        // "a" spans both rows (first rowspan=0 in the row).
+        // "b" appears only in row 0 (second rowspan=0 treated as rowspan=1).
+        // "c" fills row 1 at col 1.
+        assert_eq!(result[0].to_csv().unwrap(), "a,b\na,c\n");
+    }
 }

--- a/src/node_utils.rs
+++ b/src/node_utils.rs
@@ -89,6 +89,7 @@ fn node_to_table<'a>(node: impl Into<Node<'a>>) -> Result<Table<Node<'a>>, Error
     let t = TableSupport(node.into());
     let tr_nodes = t.tr_nodes()?;
     for (row_index, tr_node) in tr_nodes.iter().enumerate() {
+        let mut rowspan_zero_seen = false;
         for td_node in t.td_nodes(*tr_node)? {
             let mut col_index = 0;
             let Some(element) = td_node.element() else {
@@ -98,7 +99,14 @@ fn node_to_table<'a>(node: impl Into<Node<'a>>) -> Result<Table<Node<'a>>, Error
             };
             let (mut row_size, col_size) = element_utils::extract_rowspan_and_colspan(element);
             let remaining_rows = tr_nodes.len() - row_index;
-            if row_size == 0 || row_size > remaining_rows {
+            if row_size == 0 {
+                if rowspan_zero_seen {
+                    row_size = 1;
+                } else {
+                    row_size = remaining_rows;
+                    rowspan_zero_seen = true;
+                }
+            } else if row_size > remaining_rows {
                 row_size = remaining_rows;
             }
             while col_index < MAX_TABLE_COLUMNS && map.contains_key(&(row_index, col_index)) {


### PR DESCRIPTION
## Summary

Add a per-row `rowspan_zero_seen` flag in `node_to_table` so that a second `rowspan=0` cell in the same row is treated as `rowspan=1` instead of also spanning to the end of the row group.

## Motivation

The HTML5 `rowspan=0` attribute means "span to the end of the enclosing row group". When a single `<tr>` contains more than one cell with `rowspan=0`, the current state machine has no record that rowspan=0 was already processed for this row. Each cell independently computes `row_size = tr_nodes.len() - row_index`, and `HashMap::insert` (line 78 of `src/node_utils.rs`) silently overwrites earlier entries when two cells resolve to the same `(row, col)` slot.

Adding the `rowspan_zero_seen` flag makes the invariant explicit: only one cell per row may claim the "span to row-group end" privilege; subsequent `rowspan=0` cells fall back to `rowspan=1`.

## Changes

- `src/node_utils.rs`: add `rowspan_zero_seen: bool` flag per outer-loop iteration; second+ `rowspan=0` in the same row uses `row_size = 1`
- `src/lib.rs`: add `test_rowspan_zero_multiple_in_same_row` regression test

## Verification

- 5/5 tests pass (`cargo test`)
- `cargo clippy`: no new warnings
- `cargo fmt --check`: no changes needed
