### PR TITLE
Prevent partial writes to caller's writer on write_csv error

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -114,22 +114,29 @@ where
     T: std::fmt::Display,
 {
     pub fn write_csv(&self, writer: &mut impl std::io::Write) -> Result<(), Error> {
-        let mut writer = csv::Writer::from_writer(writer);
-        for row in &self.rows() {
-            let mut record = csv::StringRecord::new();
-            for cell in row {
-                if let Some(item) = cell {
-                    record.push_field(&sanitize_formula_injection(&item.to_string()));
-                } else {
-                    record.push_field("");
+        let mut buf: Vec<u8> = Vec::new();
+        {
+            let mut csv_writer = csv::Writer::from_writer(&mut buf);
+            for row in &self.rows() {
+                let mut record = csv::StringRecord::new();
+                for cell in row {
+                    if let Some(item) = cell {
+                        record.push_field(&sanitize_formula_injection(&item.to_string()));
+                    } else {
+                        record.push_field("");
+                    }
                 }
+                csv_writer
+                    .write_record(&record)
+                    .map_err(|_| Error::FailedToConvertToCSV)?;
             }
-            writer
-                .write_record(&record)
+            csv_writer
+                .flush()
                 .map_err(|_| Error::FailedToConvertToCSV)?;
         }
-        writer.flush().map_err(|_| Error::FailedToConvertToCSV)?;
-        Ok(())
+        writer
+            .write_all(&buf)
+            .map_err(|_| Error::FailedToConvertToCSV)
     }
 
     pub fn to_csv(&self) -> Result<String, Error> {


### PR DESCRIPTION
## Summary

`write_csv` previously wrapped the caller's writer directly in a `csv::Writer`. When `write_record` failed and `?` triggered an early return, the `csv::Writer`'s `Drop` impl flushed its internal buffer to the caller's writer. This left partial CSV data in the caller's writer even though the function returned `Err`.

## Change

Buffer the CSV into an intermediate `Vec<u8>`. Only call `write_all` on the caller's writer after all rows have been written successfully. If any `write_record` fails, the error path discards the intermediate buffer — nothing is written to the caller's writer.

This gives callers the all-or-nothing behavior they expect from a function that returns `Err` on failure.

## Validation

- `cargo fmt --all` — no changes
- `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- `cargo test` — all 4 tests pass
