### PR TITLE
Fix README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For example, you can convert an HTML table tag to a CSV file.
 ## Usage
 
 ```rust
-use sxd_html_table::Table;
+use sxd_html_table::{extract_table_nodes_to_table, Error, Table};
 
 let html = r#"
 <table>
@@ -44,7 +44,8 @@ fn extract_table_texts_from_document(html: &str) -> Result<Vec<Table<String>>, E
     Ok(tables)
 }
 
-let table = extract_table_texts_from_document(html).unwrap();
+let tables = extract_table_texts_from_document(html).unwrap();
+let table = tables.first().unwrap();
 let csv = table.to_csv().unwrap();
 assert_eq!(csv, "header1,header2\ndata1,data2\n");
 ```


### PR DESCRIPTION
## Summary

- Add the missing imports to the README usage snippet.
- Update the snippet to use the first extracted table before calling `to_csv()`.
- Keep the example aligned with the crate's public API and the current helper pattern used in tests.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --all-features`
- `git diff --check`
- implement-validator: overall pass
