### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ let csv = table.to_csv().unwrap();
 assert_eq!(csv, "header1,header2\ndata1,data2\n");
 ```
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings`
+- **pre-push**: the above plus `cargo test`
+
+CI still runs the full suite (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
+
 ## License
 
 Licensed under either of

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,17 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: fmt
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo fmt --all -- --check
+    - name: clippy
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo clippy --all-targets --all-features -- -D warnings
+
+pre-push:
+  jobs:
+    - name: fmt
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo fmt --all -- --check
+    - name: clippy
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo clippy --all-targets --all-features -- -D warnings
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; cargo test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` so contributors can run the same fmt, clippy, and test checks as CI locally before pushing.
- Adds a `## Development` section to `README.md` explaining how to install and use the hooks.
- CI workflows are left completely unchanged.

## Changes

- `lefthook.yml` — new file; defines two hooks:
  - **pre-commit**: `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings`
  - **pre-push**: the above plus `cargo test`
- `README.md` — new `## Development` section inserted before `## License`.

## Verification

All three mirrored commands pass on the current `main` HEAD:

```
cargo fmt --all -- --check      ✔
cargo clippy --all-targets --all-features -- -D warnings  ✔
cargo test                      ✔  (8 tests passed)
```

The pre-commit hook fired during the commit and passed; the pre-push hook fired during push and passed.

## Notes

- Requires [lefthook](https://lefthook.dev/) on the developer's PATH (`lefthook install` to activate).
- Requires a working `cargo` toolchain with `rustfmt` and `clippy` components.
- No changes to `.github/workflows/` or any crate source files.
