### PR TITLE
Remove misleading Octocov code-to-test ratio setting

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,11 +2,6 @@
 coverage:
   paths:
     - coverage.lcov
-codeToTestRatio:
-  code:
-    - "src/**/*.rs"
-  test:
-    - "tests/**/*.rs"
 testExecutionTime:
   if: true
 diff:


### PR DESCRIPTION
## Summary
.octocov.yml no longer defines the misleading `codeToTestRatio` block. Coverage, testExecutionTime, diff, comment, and report settings remain unchanged.

## Validation
- YAML parse
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `typos .octocov.yml`
- `git diff --check`
- `cargo build --release --all-features`

`octocov` CLI is not available locally; GitHub Actions will validate the Octocov config.
