### PR TITLE
Add coverage acceptable threshold to octocov config

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,6 +2,7 @@
 coverage:
   paths:
     - coverage.lcov
+  acceptable: current >= 80%
 testExecutionTime:
   if: true
 diff:


### PR DESCRIPTION
## Summary

The `.octocov.yml` had coverage measurement configured but no `acceptable` threshold. Without a threshold, CI passes even when coverage degrades significantly.

## Change

Add `coverage.acceptable: current >= 80%` to enforce a minimum coverage floor. The current coverage is 95.3%, so this threshold allows reasonable variation while catching major regressions.

## Verification

- `cargo fmt`, `cargo clippy`: pass (no Rust code changed)
- Current coverage at 95.3% passes the 80% threshold