### PR TITLE
Add CONTRIBUTING.md, CHANGELOG, issue template, and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report a problem with sxd_html_table
+labels: bug
+---
+
+## Description
+
+<!-- A clear description of the bug. -->
+
+## Minimal Reproducible Example
+
+```rust
+// Paste the smallest snippet that demonstrates the issue.
+```
+
+## Expected Behaviour
+
+<!-- What did you expect to happen? -->
+
+## Actual Behaviour
+
+<!-- What actually happened? Include any error messages or panics. -->
+
+## Environment
+
+- sxd_html_table version:
+- Rust toolchain (`rustup show`):
+- OS:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Test Plan
+
+- [ ] `cargo test` passes
+- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
+- [ ] `cargo fmt --all -- --check` passes
+
+## Related Issues
+
+<!-- Closes #... -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - Initial release
+
+### Added
+
+- `extract_table_nodes_to_table`: extract HTML table nodes from an SXD document into a structured `Table`
+- `Table<T>` with support for `colspans`, `rowspans`, `<th>`/`<td>` distinction
+- CSV output via `Table::to_csv`
+- String table conversion via `Table::to_string_table`
+
+[Unreleased]: https://github.com/kitsuyui/sxd_html_table/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/kitsuyui/sxd_html_table/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to sxd_html_table
+
+Thank you for your interest in contributing!
+
+## Development Setup
+
+Prerequisites: Rust toolchain (stable). Install via [rustup](https://rustup.rs/).
+
+```sh
+git clone https://github.com/kitsuyui/sxd_html_table.git
+cd sxd_html_table
+cargo build
+```
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI locally:
+
+```sh
+lefthook install
+```
+
+## Running Tests
+
+```sh
+cargo test
+```
+
+## Code Style
+
+Format and lint before committing:
+
+```sh
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+The pre-commit hook enforces both checks automatically once you install lefthook.
+
+## Submitting Changes
+
+1. Fork the repository and create a topic branch from `main`.
+2. Make your changes and add tests for new behaviour.
+3. Run `cargo fmt`, `cargo clippy`, and `cargo test` to verify everything passes.
+4. Open a pull request against `main` and fill in the PR template.
+
+## Reporting Bugs
+
+Please use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md) when opening an issue.
+Include a minimal reproducible example whenever possible.
+
+## License
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed (MIT OR Apache-2.0) without any additional terms or conditions.


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` with development setup, test instructions, and PR workflow
- Add `.github/ISSUE_TEMPLATE/bug_report.md` so bug reporters have a structured template
- Add `.github/pull_request_template.md` with a checklist of required verifications
- Add `CHANGELOG.md` (Keep a Changelog format) to give crates.io consumers a record of changes

## Motivation

GitHub shows a `CONTRIBUTING.md` link on new issue and PR forms when the file exists at the
repository root. Without it, contributors have no guided entry point and bug reports arrive
without the information needed to reproduce them.

A `CHANGELOG.md` gives downstream users a reliable way to review what changed between releases
without having to read raw commit history or diff Cargo.toml.

## Test Plan

- [x] `cargo fmt --all -- --check` passes (no Rust source changes)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` passes (15/15)
