### PR TITLE
Enable Renovate automerge for minor/patch crate and GHA digest updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,5 +2,25 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>kitsuyui/renovate-config"
+  ],
+  "packageRules": [
+    {
+      /**
+       * Automerge minor and patch crate updates.
+       * Major version updates require explicit review.
+       */
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      /**
+       * Automerge digest-pin updates for GitHub Actions.
+       * These are non-breaking pinning updates.
+       */
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Renovate dependency update PRs have been accumulating because automerge is not configured. This PR adds automerge rules for low-risk updates so they merge automatically once CI passes.

Changes:
- `renovate.json5`: add `packageRules` to automerge cargo minor/patch updates and GitHub Actions digest-pin updates

## Why

Without automerge, all Renovate PRs require a manual merge. Minor and patch crate updates and digest-pin GHA updates are low-risk changes that CI already validates. Configuring automerge at the Renovate level means Renovate will merge these PRs directly once all checks pass, without needing the GitHub-native auto-merge setting.

## Remaining gap

`allow_auto_merge` and `allow_update_branch` are repository settings that cannot be changed via a code PR with the current token scope. These must be enabled manually via GitHub Settings or:

```
gh api -X PATCH /repos/kitsuyui/sxd_html_table -F allow_auto_merge=true -F allow_update_branch=true
```

Required status checks (e.g. the `tests` job) also need to be added to the branch protection rule via GitHub Settings.

## Verification

- `cargo fmt --all -- --check`: pass
- `cargo clippy --all-targets --all-features -- -D warnings`: pass
- `cargo test`: 15/15 pass
