### PR TITLE
Add SLSA build provenance attestation to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,10 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -55,8 +59,18 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+      - name: package
+        if: github.event_name == 'release' && !github.event.release.prerelease
+        run: cargo package --no-verify
+
+      - name: attest build provenance
+        if: github.event_name == 'release' && !github.event.release.prerelease
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: target/package/*.crate
+
       - name: publish
         if: github.event_name == 'release' && !github.event.release.prerelease
-        run: cargo publish
+        run: cargo publish --no-verify
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

Adds SLSA build provenance attestation to the crates.io publish workflow to cryptographically link published crates back to this CI run.

## Changes

- Add `id-token: write` and `attestations: write` permissions to the `publish` job
- Add `cargo package --no-verify` step to produce the `.crate` artifact before attestation
- Add `actions/attest-build-provenance@v4.1.0` step targeting `target/package/*.crate`
- Change `cargo publish` to `cargo publish --no-verify` (packaging already occurred in the preceding step)

The `CARGO_REGISTRY_TOKEN` authentication path is unchanged; this PR only adds provenance generation on top of the existing publish flow.

## Verification

Provenance attestation runs only on full releases (`!github.event.release.prerelease`), matching the existing publish gate. The dry-run path for pre-releases is not affected.

## Trade-offs

- This approach keeps the long-lived `CARGO_REGISTRY_TOKEN` secret. Migration to crates.io Trusted Publishing (OIDC) would remove the secret but requires a separate configuration step in the crates.io dashboard; that is out of scope for this change.
