### PR TITLE
ci: pin cargo-llvm-cov install version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       # For incremental builds
       CARGO_INCREMENTAL: 1
+      CARGO_LLVM_COV_VERSION: 0.8.7
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         # For incremental builds
@@ -43,7 +44,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-llvm-cov-${{ env.CARGO_LLVM_COV_VERSION }}-${{ hashFiles('**/Cargo.lock') }}
 
       - run: cargo fmt --all -- --check
 
@@ -53,5 +54,5 @@ jobs:
 
       - name: coverage
         run: |
-          cargo install cargo-llvm-cov || true  # when already cached
+          cargo install cargo-llvm-cov --version "${CARGO_LLVM_COV_VERSION}" --locked
           cargo llvm-cov --lcov --output-path coverage.lcov


### PR DESCRIPTION
## Summary
- pin the CI `cargo-llvm-cov` install to version `0.8.7`
- include the coverage tool version in the Cargo cache key
- remove the `|| true` fallback so coverage tool installation failures are visible

## Tests
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check`
- `cargo test`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `cargo install cargo-llvm-cov --version 0.8.7 --locked --root /tmp/cargo-llvm-cov-0.8.7-check`
- `PATH=/tmp/cargo-llvm-cov-0.8.7-check/bin:$PATH cargo llvm-cov --version`
- collateral check clean

## Notes
`implement-validator` is unavailable in this environment (not in PATH; no repo binary found), so this PR uses the repository checks above as the publish gate.
