### PR TITLE
supply-chain: add deny.toml to declare cargo-deny license allowlist

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,27 @@
+[advisories]
+# Deny known security vulnerabilities; warn on unmaintained crates.
+# sxd-document and sxd-xpath have no upstream activity since ~2021 and are
+# knowingly used as core dependencies. No RUSTSEC advisories exist for them
+# today. This config will surface any future advisories immediately via CI.
+ignore = []
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+]
+confidence-threshold = 0.8
+exceptions = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary

Add `deny.toml` at the repository root to declare an explicit license allowlist for `cargo deny`.

Without this file, `cargo deny check` rejects all crates by default, making supply-chain audits non-actionable. With the allowlist in place, the tool produces meaningful results: it will pass for current dependencies and surface any future license or advisory issues.

## Changes

- `deny.toml`: new file declaring `[licenses]`, `[advisories]`, `[bans]`, and `[sources]` policy

## License allowlist rationale

All current transitive dependencies carry MIT or Apache-2.0 licenses (verified against `Cargo.lock`). The allowlist includes the common OSI-approved permissive licenses used in the Rust ecosystem as a forward-compatible baseline, matching the pattern in the sibling [`sxd_html`](https://github.com/kitsuyui/sxd_html) crate.

## Verification

```
cargo deny check
# advisories ok, bans ok, licenses ok, sources ok
```

## Trade-offs

- `cargo deny check` is not yet wired into CI — running it requires calling it manually or via an external audit pipeline. Adding CI enforcement is a separate improvement.
- The allowlist includes a small set of precautionary licenses (`Apache-2.0 WITH LLVM-exception`, `BSD-3-Clause`, `ISC`, `Unicode-3.0`) not currently in use; these produce `license-not-encountered` warnings, which are informational-only.
